### PR TITLE
Fix fresh-install package failure + document forensic dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ Every tool call, DAIR call, reason call, and confirmed finding is written to a l
 
    The submission runs both on `claude` with Opus (see [How it works](#how-it-works)) — the simplest setup is to add an `ANTHROPIC_API_KEY` and you're done. TRUDI will start without a backend configured, but that is **not a supported way to evaluate it**: reason and DAIR calls are skipped and you're seeing a hollowed-out agent, not TRUDI.
 
+### System forensic packages
+
+`install.sh` installs these automatically (and enables the `universe` apt component if needed). On a full SIFT Workstation most are already present; on a leaner base, or if the installer logs a `!` warning about one, install them by hand:
+
+```bash
+sudo add-apt-repository -y universe        # pst-utils / pff-tools / tcpxtract live here
+sudo apt-get update
+sudo apt-get install -y pff-tools pst-utils binwalk tcpxtract sleuthkit ewf-tools
+```
+
+| apt package | Binaries | TRUDI tools that need it |
+|-------------|----------|--------------------------|
+| `pff-tools` | `pffexport`, `pffinfo` | `misc.pff_export` (PST/OST email extraction) |
+| `pst-utils` | `readpst`, `lspst` | `misc.readpst_extract` (PST→mbox) — **not** `libpst-utils`; that package does not exist |
+| `sleuthkit` | `fls`, `icat`, `istat`, `mmls`, `blkls`, `mactime`, `tsk_recover` | `tsk.*` |
+| `ewf-tools` | `ewfmount`, `ewfinfo`, `ewfverify` | `ewf.*`, `img.*` E01 mounting |
+| `tcpxtract` | `tcpxtract` | `net.tcpxtract_streams` |
+| `binwalk` | `binwalk` | firmware / embedded carving |
+| **chainsaw** (GitHub release `v2.10.2` → `/usr/local/bin`, not apt) | `chainsaw` | `misc.chainsaw_hunt` (Sigma over EVTX) — optional; TRUDI runs without it |
+
+Verify after install: `for b in pffexport readpst fls ewfmount tcpxtract; do command -v "$b" || echo "MISSING: $b"; done`
+
 ---
 
 ## Setup

--- a/docs/try-it-out.md
+++ b/docs/try-it-out.md
@@ -33,7 +33,7 @@ cd ~/trudi
 `install.sh` is idempotent — safe to re-run. It will:
 
 - Verify `python3`, `dotnet`, and the `claude` CLI
-- Install missing apt forensic packages (pff-tools, pst-utils, sleuthkit, ewf-tools, …) and chainsaw
+- Enable the `universe` apt component if missing, then install the forensic packages below and chainsaw
 - Create a venv at `~/.venv` and install all Python dependencies
 - Install the dashboard launcher (`trudi-dashboard` → `/usr/local/bin`)
 - Copy the MITRE ATT&CK table and the **bundled case studies** into `~/cases/` (existing cases are never overwritten)
@@ -43,6 +43,31 @@ cd ~/trudi
 - Run the test suite (1,100+ tests) as a smoke check
 
 When it finishes you have a working install and eight bundled runs to browse.
+
+### System forensic packages
+
+`install.sh` installs these from apt automatically. On a full SIFT Workstation most are already present; on a leaner base — or if the installer prints a `!` warning about one — install them by hand. The `universe` component must be enabled first (these packages live there):
+
+```bash
+sudo add-apt-repository -y universe
+sudo apt-get update
+sudo apt-get install -y pff-tools pst-utils binwalk tcpxtract sleuthkit ewf-tools
+```
+
+| apt package | Binary | TRUDI tools |
+|-------------|--------|-------------|
+| `pff-tools` | `pffexport` | `misc.pff_export` (PST/OST email) |
+| `pst-utils` | `readpst` | `misc.readpst_extract` (PST→mbox) — **not** `libpst-utils` |
+| `sleuthkit` | `fls`, `icat`, `mmls`, … | `tsk.*` |
+| `ewf-tools` | `ewfmount`, `ewfverify` | `ewf.*`, `img.*` (E01) |
+| `tcpxtract` | `tcpxtract` | `net.tcpxtract_streams` |
+| `binwalk` | `binwalk` | embedded carving |
+
+chainsaw (Sigma over EVTX, `misc.chainsaw_hunt`) is fetched from its GitHub release into `/usr/local/bin` and is optional — TRUDI runs without it. Verify the apt set landed:
+
+```bash
+for b in pffexport readpst fls ewfmount tcpxtract; do command -v "$b" || echo "MISSING: $b"; done
+```
 
 ---
 
@@ -184,6 +209,8 @@ cd ~/trudi && source ~/.venv/bin/activate && pytest -q
 | Volatility plugin times out / `-1` exit | Symbols not cached — run `vol.symbol_check` on the image first; raise `TRUDI_VOL_TIMEOUT` in `.env` on slow hardware. |
 | EZ Tools fail | `dotnet` missing — install the SIFT Workstation, which bundles the .NET runtime. |
 | `claude: command not found` | Install Protocol SIFT first (it installs Claude Code). |
+| `Unable to locate package <pst-utils/pff-tools/tcpxtract>` | `universe` apt component not enabled, or apt index stale on a fresh image. `sudo add-apt-repository -y universe && sudo apt-get update`, then re-run `./install.sh`. (The package is `pst-utils`, never `libpst-utils`.) |
+| `misc.readpst_extract` / `misc.pff_export` fail with "not installed" | `pst-utils` / `pff-tools` missing — see [System forensic packages](#system-forensic-packages). |
 | Hooks not firing | Open `/hooks` in Claude Code once to reload, or restart the session. |
 
 ---

--- a/docs/try-it-out.md
+++ b/docs/try-it-out.md
@@ -33,7 +33,7 @@ cd ~/trudi
 `install.sh` is idempotent — safe to re-run. It will:
 
 - Verify `python3`, `dotnet`, and the `claude` CLI
-- Install missing apt forensic packages (pff-tools, libpst-utils, sleuthkit, ewf-tools, …) and chainsaw
+- Install missing apt forensic packages (pff-tools, pst-utils, sleuthkit, ewf-tools, …) and chainsaw
 - Create a venv at `~/.venv` and install all Python dependencies
 - Install the dashboard launcher (`trudi-dashboard` → `/usr/local/bin`)
 - Copy the MITRE ATT&CK table and the **bundled case studies** into `~/cases/` (existing cases are never overwritten)

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,7 @@ step "Installing system forensic packages"
 
 APT_PACKAGES=(
     pff-tools          # pffexport — PST/OST email extraction
-    pst-utils          # readpst — PST→mbox conversion (NOT libpst-utils; that pkg name does not exist)
+    pst-utils          # readpst — PST→mbox conversion
     binwalk            # firmware / embedded carving
     tcpxtract          # network stream carving (already covered)
     sleuthkit          # TSK tools
@@ -77,8 +77,8 @@ if [ "${#MISSING_PKGS[@]}" -gt 0 ]; then
     sudo apt-get install -y "${MISSING_PKGS[@]}" || \
         warn "Some apt packages failed to install — see output above"
 
-    # Verify the critical binaries actually landed — dpkg state alone hid the old
-    # libpst-utils typo (apt failed, '|| warn' swallowed it, readpst was never present).
+    # Verify the critical binaries actually landed — dpkg state alone can report
+    # success while an apt failure (swallowed by '|| warn' above) left a tool absent.
     for bin in readpst pffexport; do
         command -v "$bin" &>/dev/null || warn "Expected binary '$bin' not found after install — email extraction (misc.readpst_extract / misc.pff_export) will fail"
     done
@@ -101,9 +101,12 @@ else
     CHAINSAW_URL="https://github.com/WithSecureLabs/chainsaw/releases/download/v${CHAINSAW_VERSION}/chainsaw_x86_64-unknown-linux-gnu.tar.gz"
     TMPDIR=$(mktemp -d)
     if curl -fsSL "$CHAINSAW_URL" -o "$TMPDIR/chainsaw.tgz" 2>/dev/null; then
-        tar -xzf "$TMPDIR/chainsaw.tgz" -C "$TMPDIR"
+        # Guard extraction: a corrupt download must degrade to the optional-skip
+        # path, not abort the whole install under `set -e`.
         # Release ships as chainsaw/chainsaw + sigma rules
-        if [ -f "$TMPDIR/chainsaw/chainsaw" ]; then
+        if ! tar -xzf "$TMPDIR/chainsaw.tgz" -C "$TMPDIR" 2>/dev/null; then
+            warn "chainsaw archive corrupt — skipping (TRUDI works without it)"
+        elif [ -f "$TMPDIR/chainsaw/chainsaw" ]; then
             sudo install -m 0755 "$TMPDIR/chainsaw/chainsaw" "$CHAINSAW_BIN"
             if [ -d "$TMPDIR/chainsaw/sigma" ]; then
                 sudo mkdir -p /usr/local/share/chainsaw
@@ -166,9 +169,6 @@ if [ -f "$MITRE_DEST" ]; then
 elif [ -f "$MITRE_SRC" ]; then
     cp "$MITRE_SRC" "$MITRE_DEST"
     ok "Installed MITRE reference table → $MITRE_DEST"
-elif [ -f "/home/trin/cases/.common/mitre_techniques.json" ]; then
-    cp "/home/trin/cases/.common/mitre_techniques.json" "$MITRE_DEST"
-    ok "Copied MITRE reference table → $MITRE_DEST"
 else
     warn "MITRE reference table not found in repo; mitre_map will be a no-op"
 fi
@@ -388,17 +388,36 @@ if "$CLAUDE_BIN" mcp list 2>/dev/null | grep -q "trudi-sift"; then
     "$CLAUDE_BIN" mcp remove trudi-sift 2>/dev/null || true
 fi
 
-"$CLAUDE_BIN" mcp add trudi-sift "$PYTHON_BIN" "$SERVER_PATH" --scope user 2>/dev/null || \
-"$CLAUDE_BIN" mcp add trudi-sift "$PYTHON_BIN" "$SERVER_PATH" --scope global 2>/dev/null || true
-ok "Registered trudi-sift MCP server (global scope)"
+# Register at user scope, falling back to global. Do NOT hide stderr or '|| true'
+# the failure: the MCP server IS the product, so a silent registration failure
+# would leave a hollow Claude with a misleading "ready" banner. Verify after.
+if "$CLAUDE_BIN" mcp add trudi-sift "$PYTHON_BIN" "$SERVER_PATH" --scope user; then
+    REG_SCOPE="user"
+elif "$CLAUDE_BIN" mcp add trudi-sift "$PYTHON_BIN" "$SERVER_PATH" --scope global; then
+    REG_SCOPE="global"
+else
+    REG_SCOPE=""
+fi
+
+if [ -n "$REG_SCOPE" ] && "$CLAUDE_BIN" mcp list 2>/dev/null | grep -q "trudi-sift"; then
+    ok "Registered trudi-sift MCP server ($REG_SCOPE scope)"
+else
+    fail "Failed to register trudi-sift MCP server — TRUDI has no tools without it. Reproduce: $CLAUDE_BIN mcp add trudi-sift $PYTHON_BIN $SERVER_PATH --scope user"
+fi
 
 # ── 7. Verify ─────────────────────────────────────────────────────────────────
 
 step "Running smoke test"
 
 cd "$TRUDI_DIR"
-"$VENV_DIR/bin/python3" -m pytest tests/ -q --tb=short 2>&1 | tail -5
-ok "Tests passed"
+# The install is already complete by this point — a failing test should not abort
+# the script under `set -e` and hide the "TRUDI is ready" banner. Warn instead.
+if "$VENV_DIR/bin/python3" -m pytest tests/ -q --tb=short; then
+    ok "Tests passed"
+else
+    rc=$?
+    warn "pytest reported failures (exit $rc) — the install itself is complete; review the output above before relying on this build"
+fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,7 @@ step "Installing system forensic packages"
 
 APT_PACKAGES=(
     pff-tools          # pffexport — PST/OST email extraction
-    libpst-utils       # readpst — PST→mbox conversion
+    pst-utils          # readpst — PST→mbox conversion (NOT libpst-utils; that pkg name does not exist)
     binwalk            # firmware / embedded carving
     tcpxtract          # network stream carving (already covered)
     sleuthkit          # TSK tools
@@ -63,9 +63,25 @@ for pkg in "${APT_PACKAGES[@]}"; do
     fi
 done
 if [ "${#MISSING_PKGS[@]}" -gt 0 ]; then
+    # pst-utils, pff-tools, and tcpxtract live in the 'universe' component.
+    # SIFT normally enables it, but a bare Ubuntu base may not — make it explicit
+    # so a fresh image doesn't fail with "unable to locate package".
+    if ! grep -rq "^deb .* universe" /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
+        if command -v add-apt-repository &>/dev/null; then
+            sudo add-apt-repository -y universe || warn "Could not enable 'universe' repo automatically"
+        else
+            warn "'universe' repo not enabled and add-apt-repository missing — pst-utils/pff-tools may not install"
+        fi
+    fi
     sudo apt-get update -qq
     sudo apt-get install -y "${MISSING_PKGS[@]}" || \
         warn "Some apt packages failed to install — see output above"
+
+    # Verify the critical binaries actually landed — dpkg state alone hid the old
+    # libpst-utils typo (apt failed, '|| warn' swallowed it, readpst was never present).
+    for bin in readpst pffexport; do
+        command -v "$bin" &>/dev/null || warn "Expected binary '$bin' not found after install — email extraction (misc.readpst_extract / misc.pff_export) will fail"
+    done
     ok "Installed: ${MISSING_PKGS[*]}"
 else
     ok "All apt forensic packages already present"

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -1113,7 +1113,7 @@ def readpst_extract(pst_path: str, output_dir: str, format_mbox: bool = True) ->
     """
     binary = _bin_or_warn("readpst")
     if not binary:
-        return {"success": False, "error": "readpst not installed — apt install libpst-utils"}
+        return {"success": False, "error": "readpst not installed — sudo apt install pst-utils"}
     os.makedirs(output_dir, exist_ok=True)
     cmd = [binary, "-o", output_dir]
     if not format_mbox:


### PR DESCRIPTION
## Summary

Fixes a fresh-install blocker and documents the system dependencies that caused it, so a judge can install/verify TRUDI on a clean SIFT/VMware image without hitting silent failures.

### Install fix (`f00345f`)
- `install.sh` referenced **`libpst-utils`**, which is not a real Ubuntu package — a fresh install failed with `Unable to locate package`. The package that provides `readpst` is **`pst-utils`**.
- Changes: rename to `pst-utils`; enable the `universe` apt component if missing (`pst-utils`/`pff-tools`/`tcpxtract` live there); **verify `readpst`/`pffexport` binaries exist** after install instead of trusting dpkg state. Runtime hint in `tools/misc.py` and the Try-It-Out doc corrected to `pst-utils`.

### Dependency docs (`401d3f9`)
- README and `docs/try-it-out.md` only gestured at the apt packages. Added an authoritative **System forensic packages** table (package → binaries → TRUDI tools) with manual install + verify commands, and troubleshooting rows for the exact `Unable to locate package` error.

### Also on this branch (pre-existing `3d9a5e9`)
- accuracy-report TOC, required-backends prereqs, vanko console.log accuracy.

## Test
- `bash -n install.sh` passes; `apt-cache show pst-utils` confirms the package resolves.
- Not validated by a full clean-image run (no fresh VM / Docker available in this environment) — the package name and repo logic are correct, but an end-to-end run on a throwaway SIFT VM is still recommended before relying on it for judging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)