### PR TITLE
Fix venv creation failure on the SIFT base (ensurepip missing)

### DIFF
--- a/docs/try-it-out.md
+++ b/docs/try-it-out.md
@@ -211,6 +211,7 @@ cd ~/trudi && source ~/.venv/bin/activate && pytest -q
 | `claude: command not found` | Install Protocol SIFT first (it installs Claude Code). |
 | `Unable to locate package <pst-utils/pff-tools/tcpxtract>` | `universe` apt component not enabled, or apt index stale on a fresh image. `sudo add-apt-repository -y universe && sudo apt-get update`, then re-run `./install.sh`. (The package is `pst-utils`, never `libpst-utils`.) |
 | `misc.readpst_extract` / `misc.pff_export` fail with "not installed" | `pst-utils` / `pff-tools` missing — see [System forensic packages](#system-forensic-packages). |
+| venv step fails: `ensurepip is not available` | `python3-venv` not installed — **the SIFT base does not ship it** for its default `python3`. `sudo apt-get install -y python3-venv python3-pip`, then `rm -rf ~/.venv` and re-run `./install.sh`. |
 | Hooks not firing | Open `/hooks` in Claude Code once to reload, or restart the session. |
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -45,9 +45,11 @@ ok "Claude Code at $CLAUDE_BIN"
 
 # ── 1b. System packages (apt) ─────────────────────────────────────────────────
 
-step "Installing system forensic packages"
+step "Installing system packages (Python base + forensic tools)"
 
 APT_PACKAGES=(
+    python3-venv       # ensurepip — required by `python3 -m venv` (NOT preinstalled on the SIFT base)
+    python3-pip        # pip bootstrap for the venv
     pff-tools          # pffexport — PST/OST email extraction
     pst-utils          # readpst — PST→mbox conversion
     binwalk            # firmware / embedded carving
@@ -218,8 +220,14 @@ fi
 
 step "Setting up Python environment"
 
-if [ ! -d "$VENV_DIR" ]; then
-    python3 -m venv "$VENV_DIR"
+# A partial venv from a previous failed run (e.g. one that died at ensurepip)
+# leaves the directory but no working pip — treat that as needing recreation,
+# otherwise the pip steps below fail with a confusing error.
+if [ ! -x "$VENV_DIR/bin/pip" ]; then
+    [ -d "$VENV_DIR" ] && rm -rf "$VENV_DIR"
+    if ! python3 -m venv "$VENV_DIR"; then
+        fail "Failed to create venv — 'python3 -m venv' needs ensurepip (package python3-venv). Install it and re-run: sudo apt-get install -y python3-venv python3-pip"
+    fi
     ok "Created venv at $VENV_DIR"
 else
     ok "Venv already exists at $VENV_DIR"


### PR DESCRIPTION
## Summary

`install.sh`'s venv step fails with **`ensurepip is not available`** on the SANS SIFT Workstation base — `python3-venv` is **not preinstalled** for SIFT's default `python3` (3.10), so `python3 -m venv` can't bootstrap pip. This blocks the installer on the **primary target platform**, not just minimal images.

## Changes
- **install.sh** — add `python3-venv` + `python3-pip` to the apt package set so they install (with the universe-enable + verify path) *before* the venv step; relabel the step "Python base + forensic tools".
- **install.sh** — harden the venv step: detect a partial/broken venv (directory present but no working `pip` — e.g. a prior run that died at ensurepip), `rm -rf` and recreate it, and `fail` with an actionable hint instead of letting the downstream `pip install` throw a confusing error.
- **docs/try-it-out.md** — troubleshooting row for the `ensurepip` error.

## Test
- `bash -n install.sh` passes; confirmed `python3-venv` resolves to `python3.10-venv` on the SIFT base and restores `ensurepip`.
- Found on an actual fresh SIFT VMware install; not yet validated by a full clean re-run end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
