### PR TITLE
Fresh-install hardening on SIFT base (venv version-match, pip progress, 5 smoke-test fixes)

### DIFF
--- a/docs/try-it-out.md
+++ b/docs/try-it-out.md
@@ -13,9 +13,11 @@ Two ways to evaluate TRUDI, shortest first:
 
 ## Prerequisites
 
+> **Reference platform.** This walkthrough was run on the **SANS SIFT Workstation VMware image, release 2026-04-22 (Ubuntu 24.04.4 LTS, x86-64, `python3` 3.12)**. Other SIFT releases work, but package versions (notably the `pythonX.Y-venv` the installer needs) track the base Ubuntu — see [Troubleshooting](#troubleshooting).
+
 | Need | For | Notes |
 |------|-----|-------|
-| **SANS SIFT Workstation** (Ubuntu 22.04 x86-64) | Path B (the forensic tools) | Path A only needs Python 3.10+ and a browser. [Download](https://www.sans.org/tools/sift-workstation/) |
+| **SANS SIFT Workstation** (Ubuntu 24.04 x86-64) | Path B (the forensic tools) | Path A only needs Python 3.10+ and a browser. [Download](https://www.sans.org/tools/sift-workstation/) |
 | **Protocol SIFT** (Claude Code + skill playbooks) | Both | [github.com/teamdfir/protocol-sift](https://github.com/teamdfir/protocol-sift) |
 | **Python 3.10+** and **dotnet** | Both | Included in SIFT |
 | **`ANTHROPIC_API_KEY`** | Path B (full-quality) | Powers the analyst + `reason.*` + `dair.*`. See the degradation note above. |

--- a/docs/try-it-out.md
+++ b/docs/try-it-out.md
@@ -211,7 +211,7 @@ cd ~/trudi && source ~/.venv/bin/activate && pytest -q
 | `claude: command not found` | Install Protocol SIFT first (it installs Claude Code). |
 | `Unable to locate package <pst-utils/pff-tools/tcpxtract>` | `universe` apt component not enabled, or apt index stale on a fresh image. `sudo add-apt-repository -y universe && sudo apt-get update`, then re-run `./install.sh`. (The package is `pst-utils`, never `libpst-utils`.) |
 | `misc.readpst_extract` / `misc.pff_export` fail with "not installed" | `pst-utils` / `pff-tools` missing — see [System forensic packages](#system-forensic-packages). |
-| venv step fails: `ensurepip is not available` | `python3-venv` not installed — **the SIFT base does not ship it** for its default `python3`. `sudo apt-get install -y python3-venv python3-pip`, then `rm -rf ~/.venv` and re-run `./install.sh`. |
+| venv step fails: `ensurepip is not available` | The venv package matching your `python3` isn't installed — **the SIFT base does not ship it** (SIFT's `python3` is 3.12). Install the **version-matched** package, not just the metapackage: `sudo apt-get install -y python3.12-venv python3-pip` (replace `3.12` with `python3 --version`), then `rm -rf ~/.venv` and re-run `./install.sh`. (`install.sh` now auto-installs the matching `pythonX.Y-venv` and retries.) |
 | Hooks not firing | Open `/hooks` in Claude Code once to reload, or restart the session. |
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -223,10 +223,21 @@ step "Setting up Python environment"
 # A partial venv from a previous failed run (e.g. one that died at ensurepip)
 # leaves the directory but no working pip — treat that as needing recreation,
 # otherwise the pip steps below fail with a confusing error.
+make_venv() { [ -d "$VENV_DIR" ] && rm -rf "$VENV_DIR"; python3 -m venv "$VENV_DIR" 2>/dev/null; }
+
 if [ ! -x "$VENV_DIR/bin/pip" ]; then
-    [ -d "$VENV_DIR" ] && rm -rf "$VENV_DIR"
-    if ! python3 -m venv "$VENV_DIR"; then
-        fail "Failed to create venv — 'python3 -m venv' needs ensurepip (package python3-venv). Install it and re-run: sudo apt-get install -y python3-venv python3-pip"
+    if ! make_venv; then
+        # ensurepip is missing. The generic python3-venv metapackage tracks the
+        # apt-default python, which on a multi-python box (e.g. SIFT's python3.12)
+        # differs from the `python3` command — so install the venv package matching
+        # THIS python3 by version, then retry.
+        PYV="$(python3 -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')"
+        warn "venv creation failed (ensurepip missing) — installing python${PYV}-venv to match python3 $PYV"
+        sudo apt-get install -y "python${PYV}-venv" python3-pip 2>/dev/null || \
+            sudo apt-get install -y python3-venv python3-pip 2>/dev/null || true
+        if ! make_venv; then
+            fail "Failed to create venv even after installing python${PYV}-venv. Install it manually and re-run: sudo apt-get install -y python${PYV}-venv python3-pip"
+        fi
     fi
     ok "Created venv at $VENV_DIR"
 else


### PR DESCRIPTION
## Summary

Fresh-install hardening for the SANS SIFT base, found by running `install.sh` end-to-end on the SIFT VMware image (release 2026-04-22, **Ubuntu 24.04.4 LTS, python3 3.12**). Each item is something the SIFT base does *not* provide that the dev environment masked.

## Changes

**Installer (`install.sh`)**
- **Version-matched venv** — PR #9's generic `python3-venv` metapackage tracks the apt-default python; SIFT's `python3` is 3.12, so it installed the wrong version's venv and `python3 -m venv` still failed with `ensurepip is not available`. The venv step is now self-healing: detect the running python's `X.Y`, `apt-get install python${X.Y}-venv`, and retry before failing with a version-specific hint.
- **pip progress** — the dependency install used `pip --quiet`, so the heavy packages (flare-capa/flare-floss/yara-python, minutes to fetch/compile) produced zero output and looked hung right after "Created venv at …". Dropped `--quiet` + added a heads-up.

**Smoke-test failures on a clean venv (5 → 0)**
- 4× `tests/test_middleware.py` async tests failed with "async def functions are not natively supported" — `pytest-asyncio` was never a dependency. Added it + `asyncio_mode=auto`.
- `tests/tools/test_volatility.py` tilde test hardcoded `/home/trin` and patched the global `os.path.expanduser`, which leaked into `vol3_symbols()` and made it `makedirs()` the image path (FileNotFoundError off-box). Now uses a real tmp file + pins `VOLATILITY_SYMBOLS`.
- Scrubbed remaining `/home/trin` dev paths from `tests/core/test_paths.py` and `tests/regression/*`.

**Docs (`docs/try-it-out.md`)**
- Reference-platform callout (SIFT 2026-04-22 / Ubuntu 24.04.4 / python 3.12); fixed stale "Ubuntu 22.04" prerequisite.
- Troubleshooting rows for the `ensurepip` error (version-matched command).

## Test
- `bash -n install.sh` passes; full suite **1133 passed** locally.
- Installer portions validated on a live SIFT install through the venv + pip steps; not yet a single clean top-to-bottom re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
