### PR TITLE
Land stranded fresh-install fixes (pip progress, smoke tests, docstring scrub)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -245,8 +245,12 @@ else
 fi
 
 "$VENV_DIR/bin/pip" install --quiet --upgrade pip
-"$VENV_DIR/bin/pip" install --quiet -r "$TRUDI_DIR/requirements.txt"
-"$VENV_DIR/bin/pip" install --quiet -r "$TRUDI_DIR/requirements-dev.txt"
+# Do NOT use --quiet here: flare-capa/flare-floss (and yara-python, which compiles
+# C) are large and can take several minutes. With --quiet the step produces zero
+# output and looks hung; show pip's normal progress instead.
+warn "Installing Python dependencies — this can take several minutes (flare-capa / flare-floss / yara-python are large). Progress shown below."
+"$VENV_DIR/bin/pip" install -r "$TRUDI_DIR/requirements.txt"
+"$VENV_DIR/bin/pip" install -r "$TRUDI_DIR/requirements-dev.txt"
 ok "Dependencies installed (fastmcp, httpx, anthropic, yara-python, flare-capa, flare-floss, oletools, pytest)"
 
 # ── 4. Environment file ───────────────────────────────────────────────────────

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 testpaths = tests
 pythonpath = .
 addopts = --cov=core --cov=tools --cov-report=term-missing
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest>=8.0.0
 pytest-cov>=5.0.0
+pytest-asyncio>=0.23.0   # async middleware tests (@pytest.mark.asyncio) need this

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -17,10 +17,10 @@ class TestIsEvidencePath:
         ("/cases/example/image.E01", True),
         ("/mnt/ewf_wkstn01/ewf1", True),
         ("/media/usb/image.dd", True),
-        ("/home/trin/cases/example/evidence/image.E01", True),
-        ("/home/trin/cases/example/exports/result.csv", False),
-        ("/home/trin/cases/example/analysis/data.json", False),
-        ("/home/trin/cases/example/reports/report.md", False),
+        ("/home/analyst/cases/example/evidence/image.E01", True),
+        ("/home/analyst/cases/example/exports/result.csv", False),
+        ("/home/analyst/cases/example/analysis/data.json", False),
+        ("/home/analyst/cases/example/reports/report.md", False),
         ("/tmp/scratch.bin", False),
     ])
     def test_paths(self, path, expected):
@@ -38,7 +38,7 @@ class TestAssertOutputSafe:
 
     def test_blocks_evidence_segment(self):
         with pytest.raises(ValueError, match="protected evidence"):
-            assert_output_safe("/home/trin/cases/example/evidence/out.csv")
+            assert_output_safe("/home/analyst/cases/example/evidence/out.csv")
 
     def test_allows_analysis(self, tmp_path):
         safe = str(tmp_path / "analysis" / "out.csv")

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -33,15 +33,15 @@ the resulting trace against a hand-curated ground truth.
 
    ```bash
    python -m tests.regression.run_case \
-       --case-dir /home/trin/cases/<case> \
-       --ground-truth /home/trin/cases/<case>/ground_truth.json
+       --case-dir ~/cases/<case> \
+       --ground-truth ~/cases/<case>/ground_truth.json
    ```
 
    Exit code 0 if precision/recall meet the configured thresholds, 1 otherwise.
    Detailed output to stdout (true positives, false negatives, confidence
    downgrades).
 
-4. **CI integration**: run all cases under `/home/trin/cases/*/` that
+4. **CI integration**: run all cases under `~/cases/*/` that
    have a `ground_truth.json`, fail the build on any regression.
 
 ## Why this exists

--- a/tests/regression/run_case.py
+++ b/tests/regression/run_case.py
@@ -2,8 +2,8 @@
 
 Usage:
     python -m tests.regression.run_case \\
-        --case-dir /home/trin/cases/<case> \\
-        --ground-truth /home/trin/cases/<case>/ground_truth.json \\
+        --case-dir ~/cases/<case> \\
+        --ground-truth ~/cases/<case>/ground_truth.json \\
         [--min-recall 0.8 --max-false-positives 2]
 
 Reuses tools/accuracy.py:accuracy_compare so the scoring logic stays

--- a/tests/tools/test_volatility.py
+++ b/tests/tools/test_volatility.py
@@ -82,12 +82,20 @@ class TestVolSymbolCheck:
         assert r["success"] is True
         assert r["image"] == str(img)
 
-    def test_existing_image_with_tilde_returns_expanded_path(self, mock_run):
+    def test_existing_image_with_tilde_returns_expanded_path(self, mock_run, tmp_path, monkeypatch):
         from unittest.mock import patch
         from tools.volatility import vol_symbol_check
-        expanded = "/home/trin/cases/memory.img"
-        with patch("tools.volatility.os.path.expanduser", return_value=expanded), \
-             patch("tools.volatility.os.path.exists", return_value=True):
+        # Use a real temp file as the expansion target so the path is portable
+        # (no hardcoded home) and any real filesystem access in the tool succeeds.
+        img = tmp_path / "memory.img"
+        img.write_bytes(b"\x00" * 1024)
+        expanded = str(img)
+        # Patching os.path.expanduser is global (posixpath is shared), so it also
+        # reaches vol3_symbols()'s own expanduser for the symbol-cache dir. Pin that
+        # dir via VOLATILITY_SYMBOLS so the patch can't redirect makedirs onto the
+        # image path.
+        monkeypatch.setenv("VOLATILITY_SYMBOLS", str(tmp_path / "symbols"))
+        with patch("tools.volatility.os.path.expanduser", return_value=expanded):
             r = vol_symbol_check("~/cases/memory.img")
         assert r["success"] is True
         assert r["image"] == expanded  # resolved path, not tilde path

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -1038,7 +1038,7 @@ def clear_case_run(case_dir: str) -> dict:
       - ~/.cache/trudi/session.json (prevents auto-reconnect to stale trace)
       - ~/.claude/projects/<encoded>/memory/ files (clears case memory)
 
-    case_dir: absolute path to the case directory e.g. /home/trin/cases/example-case
+    case_dir: absolute path to the case directory e.g. ~/cases/example-case
     """
     import shutil
     import glob
@@ -1418,7 +1418,7 @@ def serve_dashboard(case_dir: str, port: int = 8765) -> dict:
     one via ~/.cache/trudi/dashboard.url and returns a URL with the case's
     trace pre-selected in the dropdown.
 
-    case_dir: absolute path of the case (e.g. /home/trin/cases/example-case).
+    case_dir: absolute path of the case (e.g. ~/cases/example-case).
               Must live under the dashboard's --cases-root.
     port: accepted for back-compat; the standalone owns its own port.
     """

--- a/tools/yara_tools.py
+++ b/tools/yara_tools.py
@@ -149,7 +149,7 @@ def yara_scan_memory_image(
     Scan a full memory image (e.g. base-wkstn-01-memory.img) with YARA rules.
     Suitable for raw memory captures — not just per-process dumps.
     rules_path: path to a .yar file or directory of .yar/.yara files.
-    Use /home/trin/trudi/rules/ for the built-in TTP rule library.
+    Use ~/trudi/rules/ for the built-in TTP rule library.
     timeout: per-scan timeout in seconds (default 300 — full images are large).
     """
     try:


### PR DESCRIPTION
## Summary

Three commits got stranded when #10 was merged at `34a3af7` — *before* these were pushed to the same branch. They never reached `main`, so the symptoms they fix are still live on `main`:

- **`b64dcb8` — pip progress.** The dependency install still uses `pip --quiet` on `main`, so the heavy packages (flare-capa/flare-floss/yara-python) produce zero output for several minutes and the install looks hung right after "Created venv at …". Drops `--quiet` on the requirements installs + adds a heads-up.
- **`f3967b4` — 5 smoke-test failures.** `main` still lacks `pytest-asyncio` (4 async middleware tests fail) and still has the fragile volatility tilde test + `/home/trin` test paths. Adds `pytest-asyncio` + `asyncio_mode=auto`; fixes the test. Full suite: **1133 passed**.
- **`255a1b2` — docstring scrub.** `main` still has `/home/trin` in `yara_tools.py` (agent-facing) and `misc.py` docstrings. Scrubbed to `~/...`.

## Test
- `bash -n install.sh` passes; full suite 1133 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
