### PR TITLE
Fix asyncio 'no current event loop' failures on Python 3.12

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 testpaths = tests
 pythonpath = .
 addopts = --cov=core --cov=tools --cov-report=term-missing
-asyncio_mode = auto
+asyncio_mode = strict

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -38,7 +38,7 @@ class TestDairGateMiddleware:
         l.configure("MW-001", str(tmp_path / "trace.json"))
         mw = NarrationMiddleware()
         with patch("core.execution_log.log", l):
-            result, call_next = asyncio.get_event_loop().run_until_complete(
+            result, call_next = asyncio.run(
                 _run_middleware(mw, "dair_assess")
             )
         # call_next was invoked → tool ran
@@ -54,7 +54,7 @@ class TestDairGateMiddleware:
         l.configure("MW-002", str(tmp_path / "trace.json"))
         mw = NarrationMiddleware()
         with patch("core.execution_log.log", l):
-            result, call_next = asyncio.get_event_loop().run_until_complete(
+            result, call_next = asyncio.run(
                 _run_middleware(mw, "vol_vol_psscan")
             )
         assert call_next.await_count == 1
@@ -73,7 +73,7 @@ class TestDairGateMiddleware:
         mw = NarrationMiddleware()
         with patch("core.execution_log.log", l):
             with pytest.raises(ToolError, match="DAIR engaged earlier"):
-                asyncio.get_event_loop().run_until_complete(
+                asyncio.run(
                     _run_middleware(mw, "vol_vol_psscan")
                 )
 
@@ -85,7 +85,7 @@ class TestDairGateMiddleware:
         l.record_dair_call("Triage", "", False, "", "", "stay", "")
         mw = NarrationMiddleware()
         with patch("core.execution_log.log", l):
-            result, call_next = asyncio.get_event_loop().run_until_complete(
+            result, call_next = asyncio.run(
                 _run_middleware(mw, "vol_vol_psscan")
             )
         assert call_next.await_count == 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,7 +38,7 @@ class TestToolCount:
             return len(mcp._tool_manager._tools)
         if hasattr(mcp, "list_tools"):
             import asyncio
-            tools = asyncio.get_event_loop().run_until_complete(mcp.list_tools())
+            tools = asyncio.run(mcp.list_tools())
             return len(tools)
         return -1  # can't count, skip assertion
 

--- a/tests/tools/test_error_surfacing.py
+++ b/tests/tools/test_error_surfacing.py
@@ -30,7 +30,7 @@ def _build_context(tool_name: str, args: dict | None = None):
 
 
 def _run_async(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _configured_log(tmp_path, case_id="ERR-CASE"):

--- a/tests/tools/test_volatility.py
+++ b/tests/tools/test_volatility.py
@@ -32,7 +32,7 @@ def mock_run_progress(run_ok):
 
 def run_async(coro):
     """Helper to run a coroutine in sync test context."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 class TestSymbolPathFlag:


### PR DESCRIPTION
## Summary

Fixes the `RuntimeError: There is no current event loop in thread 'MainThread'` smoke-test failures on the SIFT base (Python 3.12). Regression introduced by #11, which added `pytest-asyncio` + `asyncio_mode=auto`.

**Root cause (a real 3.10-vs-3.12 difference):** once pytest-asyncio runs a marked async test, it leaves the thread's current event loop unset. The next *sync* test calling `asyncio.get_event_loop().run_until_complete(...)` then raises on 3.12. On 3.10 `get_event_loop()` silently auto-creates a loop — which is exactly why it passed in the dev env (3.10) and broke on the VM (3.12).

## Changes
- Convert all `asyncio.get_event_loop().run_until_complete()` helpers to **`asyncio.run()`** (`test_server.py`, `test_error_surfacing.py`, `test_volatility.py`, `core/test_middleware.py`). `asyncio.run()` creates and owns its loop, so it's immune to ambient loop state on every Python version.
- `asyncio_mode = auto` → **`strict`**: all 4 async tests are explicitly `@pytest.mark.asyncio`, so auto was unnecessary and strict avoids auto-mode loop-management surprises.

## Test — verified on the actual Python version this time
- Installed real **Python 3.12.13** (deadsnakes), reproduced the exact `RuntimeError`, and confirmed `asyncio.run()` resolves it.
- **Full suite under Python 3.12: 1133 passed** (exit 0). Also 1133 on 3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
